### PR TITLE
Allow custom http.Clients to be used

### DIFF
--- a/force/api.go
+++ b/force/api.go
@@ -2,6 +2,7 @@ package force
 
 import (
 	"fmt"
+	"net/http"
 )
 
 const (
@@ -19,6 +20,7 @@ const (
 )
 
 type ForceApi struct {
+	Client                 http.Client
 	apiVersion             string
 	oauth                  *forceOauth
 	apiResources           map[string]string
@@ -169,6 +171,13 @@ type ChildRelationship struct {
 	CascadeDelete       bool   `json:"cascadeDelete"`
 	RestrictedDelete    bool   `json:"restrictedDelete"`
 	RelationshipName    string `json:"relationshipName"`
+}
+
+func (forceApi *ForceApi) SetClient(client http.Client) {
+	forceApi.client = client
+	if forceApi.oauth != nil {
+		forceApi.oauth.client = client
+	}
 }
 
 func (forceApi *ForceApi) getApiResources() error {

--- a/force/client.go
+++ b/force/client.go
@@ -95,7 +95,7 @@ func (forceApi *ForceApi) request(method, path string, params url.Values, payloa
 
 	// Send
 	forceApi.traceRequest(req)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := forceApi.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("Error sending %v request: %v", method, err)
 	}

--- a/force/oauth.go
+++ b/force/oauth.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	grantType    = "password"
+	grantType = "password"
 
 	invalidSessionErrorCode = "INVALID_SESSION_ID"
 )
@@ -21,6 +21,7 @@ type forceOauth struct {
 	Id          string `json:"id"`
 	IssuedAt    string `json:"issued_at"`
 	Signature   string `json:"signature"`
+	client      http.Client
 
 	clientId      string
 	clientSecret  string
@@ -73,7 +74,7 @@ func (oauth *forceOauth) Authenticate() error {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", responseType)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := oauth.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("Error sending authentication request: %v", err)
 	}


### PR DESCRIPTION
We were assuming the default client everywhere, but if you want to do things like instrument requests, a custom client is necessary!